### PR TITLE
This PR removes the pandas dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,10 @@ setup(
         ]
     },
     install_requires=[
-        'pandas',
+        'numpy',
         'pymongo',
         'pyserial',
+        'scipy',
         'six',
         'utm'
     ],

--- a/src/platypus/io/db.py
+++ b/src/platypus/io/db.py
@@ -7,7 +7,7 @@ import argparse
 import gridfs
 import logging
 import mongoengine
-import pandas
+import numpy as np
 import pymongo
 import scipy
 from . import logs
@@ -66,7 +66,7 @@ def process(db, dataset_id):
                              filename=log_record['original']['name'])
         for k, v in log_data.iteritems():
             if k in data:
-                data[k] = pandas.concat(data[k], v)
+                data[k] = np.vstack(data[k], v)
             else:
                 data[k] = v
 


### PR DESCRIPTION
Instead of `pandas`, load and save functionality uses `numpy.recarray`.

While `pandas` adds a lot of additional functionality, it is also a fairly heavy dependency and can make many simple operations like interpolation very complicated.

If `pandas` is necessary, the `numpy.recarray` structure can be converted to a `pandas.DataFrame`.
