### PR TITLE
Added `coveralls` support and removes `pandas`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,9 +3,10 @@ source =
     platypus.io
     platypus.util
 omit =
+    setup.py
+    tests/*
     */python?.?/*
     */lib-python/?.?/*.py
     */lib_pypy/_*.py
     */site-packages/ordereddict.py
     */site-packages/nose/*
-    */unittest2/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source =
+    platypus.io
+    platypus.util
+omit =
+    */python?.?/*
+    */lib-python/?.?/*.py
+    */lib_pypy/_*.py
+    */site-packages/ordereddict.py
+    */site-packages/nose/*
+    */unittest2/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - conda info -a
 
   # Install heavyweight dependencies using conda, then use setup.py for the rest.
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy coverage nosetests
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy coverage nose
   - source activate test-environment
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,32 @@ python:
   - "2.7"
   - "3.5"
 # command to install dependencies
-install: "pip install -r requirements.txt"
-# command to run tests
-script: nosetests
+install:
+  - sudo apt-get update
+  # Do this conditionally because it saves us some downloading if the
+  # version is the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda.
+  - conda info -a
+
+  # Replace dep1 dep2 ... with your dependencies
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION --file requirements.txt
+  - source activate test-environment
+  - python setup.py install
+
+# Run tests.
+script:
+  - nosetests --with-cov --cov platypus.io --cov platypus.util --cov-config .coveragerc --logging-level=INFO
+
+# Calculate coverage.
+after_success:
+  - coveralls --config_file .coveragerc

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 python:
   - "2.7"
   - "3.5"
-# command to install dependencies
+# Command to install dependencies.
+# Adapted from: http://conda.pydata.org/docs/travis.html
 install:
   # Manually install `utm` via pip because it is not in the conda repos.
   - pip install utm
@@ -22,8 +23,8 @@ install:
   # Useful for debugging any issues with conda.
   - conda info -a
 
-  # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION --file requirements.txt
+  # Install heavyweight dependencies using conda, then use setup.py for the rest.
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy
   - source activate test-environment
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,13 @@ install:
   - conda info -a
 
   # Install heavyweight dependencies using conda, then use setup.py for the rest.
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy coverage
   - source activate test-environment
+  - python setup.py install
 
 # Run tests.
 script:
-  - python setup.py nosetests
+  - nosetests --with-coverage --cover-config-file .coveragerc --logging-level=INFO
 
 # Calculate coverage.
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   # Install heavyweight dependencies using conda, then use setup.py for the rest.
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose
   - source activate test-environment
-  - pip install --yes python-coveralls nose-cov
+  - pip install python-coveralls nose-cov
   - python setup.py install
 
 # Run tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
 
 # Run tests.
 script:
-  - nosetests --with-coverage --logging-level=INFO
+  - nosetests --with-coverage --cover-config-file .coveragerc --logging-level=INFO
 
 # Calculate coverage.
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,10 @@ install:
   # Install heavyweight dependencies using conda, then use setup.py for the rest.
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy
   - source activate test-environment
-  - python setup.py test
 
 # Run tests.
 script:
-  - nosetests --with-coverage --cover-config-file .coveragerc --logging-level=INFO
+  - python setup.py nosetests
 
 # Calculate coverage.
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "3.5"
 # command to install dependencies
 install:
+  # Manually install `utm` via pip because it is not in the conda repos.
+  - pip install utm
   - sudo apt-get update
   # Do this conditionally because it saves us some downloading if the
   # version is the same.

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 
 # Run tests.
 script:
-  - nosetests --with-cov --cov-config .coveragerc --logging-level=INFO
+  - nosetests --with-coverage --cover-config-file .coveragerc --logging-level=INFO
 
 # Calculate coverage.
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 
 # Run tests.
 script:
-  - nosetests --with-cov --cov platypus.io --cov platypus.util --cov-config .coveragerc --logging-level=INFO
+  - nosetests --with-cov --cov-config .coveragerc --logging-level=INFO
 
 # Calculate coverage.
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ install:
   - conda info -a
 
   # Install heavyweight dependencies using conda, then use setup.py for the rest.
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy coverage nose
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose
   - source activate test-environment
+  - pip install --yes python-coveralls nose-cov
   - python setup.py install
 
 # Run tests.
 script:
-  - source activate test-environment
-  - nosetests --with-coverage --cover-config-file .coveragerc --logging-level=INFO
+  - nosetests --with-cov --cov-config .coveragerc --logging-level=INFO
 
 # Calculate coverage.
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,13 @@ install:
   - conda info -a
 
   # Install heavyweight dependencies using conda, then use setup.py for the rest.
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy coverage
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy coverage nosetests
   - source activate test-environment
   - python setup.py install
 
 # Run tests.
 script:
+  - source activate test-environment
   - nosetests --with-coverage --cover-config-file .coveragerc --logging-level=INFO
 
 # Calculate coverage.

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
 
 # Run tests.
 script:
-  - nosetests --with-coverage --cover-config-file .coveragerc --logging-level=INFO
+  - nosetests --with-coverage --logging-level=INFO
 
 # Calculate coverage.
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python:
 # Command to install dependencies.
 # Adapted from: http://conda.pydata.org/docs/travis.html
 install:
-  # Manually install `utm` via pip because it is not in the conda repos.
-  - pip install utm
   - sudo apt-get update
   # Do this conditionally because it saves us some downloading if the
   # version is the same.
@@ -26,7 +24,7 @@ install:
   # Install heavyweight dependencies using conda, then use setup.py for the rest.
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy
   - source activate test-environment
-  - python setup.py install
+  - python setup.py test
 
 # Run tests.
 script:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Platypus Analytics #
 
 [![Build Status](https://travis-ci.org/platypusllc/analytics.svg)](https://travis-ci.org/platypusllc/analytics)
+[![Coverage Status](https://coveralls.io/repos/github/platypusllc/analytics/badge.svg?branch=master)](https://coveralls.io/github/platypusllc/analytics?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/platypus-analytics/badge/?version=latest)](http://platypus-analytics.readthedocs.org/en/latest/?badge=latest)
 
 Python library for Platypus data analysis.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-# Inherit requirements from `pypi` + `setup.py` instead of repeating them.
-# Inspired by: https://caremad.io/2013/07/setup-vs-requirement/
---index-url https://pypi.python.org/simple/
-
--e .
+numpy
+pymongo
+scipy
+six
+utm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy
-pymongo
-scipy
-six
-utm
+# Inherit requirements from `pypi` + `setup.py` instead of repeating them.
+# Inspired by: https://caremad.io/2013/07/setup-vs-requirement/
+--index-url https://pypi.python.org/simple/
+
+--e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,3 @@
 # to generate wheels for each Python version that you support.
 
 universal=1
-
-[nosetests]
-with-coverage=1
-cover-config-file=.coveragerc
-logging-level=INFO

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,8 @@
 # to generate wheels for each Python version that you support.
 
 universal=1
+
+[nosetests]
+with-coverage=1
+cover-config-file=.coveragerc
+logging-level=INFO

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ setup(
     },
     test_suite="tests",
     install_requires=[
-        'pandas',
+        'numpy',
         'pymongo',
-        'pyserial',
+        'scipy',
         'six',
         'utm'
     ],

--- a/setup.py
+++ b/setup.py
@@ -34,16 +34,11 @@ setup(
             'import=platypus.io:import'
         ]
     },
-    test_suite="tests",
     install_requires=[
         'numpy',
         'pymongo',
         'scipy',
         'six',
         'utm'
-    ],
-    tests_require=[
-        'coverage',
-        'nose'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'utm'
     ],
     tests_require=[
-        'coverage',
-        'nose'
+        'coverage'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup, find_packages
 from codecs import open  # To use a consistent encoding
 import os
+import pip
 
 # Get the current directory path.
 here = os.path.abspath(os.path.dirname(__file__))
@@ -8,6 +9,15 @@ here = os.path.abspath(os.path.dirname(__file__))
 # Get the long description from the top-level README.
 with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
+
+# Get the dependencies from the requirements.txt file.
+# Based on: https://gist.github.com/rochacbruno/90efe90e6549721e4189
+requirements = pip.req.parse_requirements(
+    'requirements.txt', session=pip.download.PipSession())
+dependency_links = [str(item.link) for item in requirements
+                    if getattr(item, 'link', None)]
+install_requires = [str(item.req) for item in requirements
+                    if item.req]
 
 # Configure python distribution package.
 setup(
@@ -34,13 +44,7 @@ setup(
             'import=platypus.io:import'
         ]
     },
-    install_requires=[
-        'numpy',
-        'pymongo',
-        'pyserial',
-        'scipy',
-        'six',
-        'utm'
-    ],
     test_suite="tests",
+    install_requires=install_requires,
+    dependency_links=dependency_links
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup, find_packages
 from codecs import open  # To use a consistent encoding
 import os
-import pip
 
 # Get the current directory path.
 here = os.path.abspath(os.path.dirname(__file__))
@@ -9,15 +8,6 @@ here = os.path.abspath(os.path.dirname(__file__))
 # Get the long description from the top-level README.
 with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
-
-# Get the dependencies from the requirements.txt file.
-# Based on: https://gist.github.com/rochacbruno/90efe90e6549721e4189
-requirements = pip.req.parse_requirements(
-    'requirements.txt', session=pip.download.PipSession())
-dependency_links = [str(item.link) for item in requirements
-                    if getattr(item, 'link', None)]
-install_requires = [str(item.req) for item in requirements
-                    if item.req]
 
 # Configure python distribution package.
 setup(
@@ -45,6 +35,15 @@ setup(
         ]
     },
     test_suite="tests",
-    install_requires=install_requires,
-    dependency_links=dependency_links
+    install_requires=[
+        'pandas',
+        'pymongo',
+        'pyserial',
+        'six',
+        'utm'
+    ],
+    tests_require=[
+        'coverage'
+        'nosetests'
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'utm'
     ],
     tests_require=[
-        'coverage'
+        'coverage',
         'nosetests'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'utm'
     ],
     tests_require=[
-        'coverage'
+        'coverage',
+        'nose'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,10 @@ setup(
         ]
     },
     install_requires=[
-        'pandas',
+        'numpy',
         'pymongo',
         'pyserial',
+        'scipy',
         'six',
         'utm'
     ],

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(
     ],
     tests_require=[
         'coverage',
-        'nosetests'
+        'nose'
     ]
 )

--- a/src/platypus/io/db.py
+++ b/src/platypus/io/db.py
@@ -7,7 +7,7 @@ import argparse
 import gridfs
 import logging
 import mongoengine
-import pandas
+import numpy as np
 import pymongo
 import scipy
 from . import logs
@@ -66,7 +66,7 @@ def process(db, dataset_id):
                              filename=log_record['original']['name'])
         for k, v in log_data.iteritems():
             if k in data:
-                data[k] = pandas.concat(data[k], v)
+                data[k] = np.vstack(data[k], v)
             else:
                 data[k] = v
 

--- a/src/platypus/io/logs.py
+++ b/src/platypus/io/logs.py
@@ -337,19 +337,19 @@ def read_v4_0_0(logfile, filename):
     # For known types, clean up and label the data.
     data = {}
 
-    for k, v in six.viewitems(raw_data):
-        if k == 'pose':
-            data['pose'] = add_ll_to_pose_dataframe(
-                remove_outliers_from_pose_dataframe(
-                    np.rec.array(v, dtype=[('time', 'datetime64[ms]'),
-                                           ('easting', float),
-                                           ('northing', float),
-                                           ('altitude', float),
-                                           ('zone', int),
-                                           ('hemi', bool)])
-                )
+    data['pose'] = add_ll_to_pose_dataframe(
+            remove_outliers_from_pose_dataframe(
+                np.rec.array(data_pose, dtype=[('time', 'datetime64[ms]'),
+                                               ('easting', float),
+                                               ('northing', float),
+                                               ('altitude', float),
+                                               ('zone', int),
+                                               ('hemi', bool)])
             )
-        elif k in _DATA_FIELDS_v4_0_0:
+        )
+
+    for k, v in six.viewitems(data_sensors):
+        if k in _DATA_FIELDS_v4_0_0:
             fields = [('time', 'datetime64[ms]')]
             fields += [(field_name, float)
                        for field_name in _DATA_FIELDS_v4_2_0[k]]

--- a/src/platypus/io/logs.py
+++ b/src/platypus/io/logs.py
@@ -364,7 +364,7 @@ def read_v4_0_0(logfile, filename):
         sensor_type: np.array(
             sensor_value,
             dtype=[('time', 'datetime64[ms]')] +
-                  [('channel' + i, float)
+                  [('channel{:d}'.format(i), float)
                    for i, _ in enumerate(sensor_value[0])]
         )
         for sensor_type, sensor_value in six.viewitems(data_sensors)

--- a/src/platypus/io/logs.py
+++ b/src/platypus/io/logs.py
@@ -174,7 +174,7 @@ def read_v4_2_0(logfile):
             # provide an unlabeled data frame.
             fields = [('time', 'datetime64[ms]')]
             fields += [float] * len(v[0])
-            data[k] = np.rec.array(v, dtype=fields)
+            data[k] = np.array(v, dtype=fields)
 
     return data
 
@@ -252,7 +252,7 @@ def read_v4_1_0(logfile):
             # provide an unlabeled data frame.
             fields = [('time', 'datetime64[ms]')]
             fields += [float] * len(v[0])
-            data[k] = np.rec.array(v, dtype=fields)
+            data[k] = np.array(v, dtype=fields)
 
     return data
 
@@ -361,7 +361,7 @@ def read_v4_0_0(logfile, filename):
     # For sensor types that we don't know how to handle,
     # provide an unlabeled data frame.
     unlabeled_sensor_data = {
-        sensor_type: np.rec.array(
+        sensor_type: np.array(
             sensor_value,
             dtype=[('time', 'datetime64[ms]')] + [float] * len(sensor_value[0])
         )

--- a/src/platypus/io/logs.py
+++ b/src/platypus/io/logs.py
@@ -76,7 +76,7 @@ This format is used in v4.2.0 vehicle log entries.
 
 _DATA_FIELDS_v4_0_0 = {
     'battery': ('voltage', 'm0_current', 'm1_current'),
-    'es2': ('ec', 'temp'),
+    'es2': ('ec', 'temperature'),
     'atlas_do': ('do',),
     'atlas_ph': ('ph',),
 }
@@ -86,7 +86,7 @@ Defines dataframe field names for known data types in v4.0.0 logfiles.
 
 _DATA_FIELDS_v4_1_0 = {
     'BATTERY': ('voltage', 'm0_current', 'm1_current'),
-    'ES2': ('ec', 'temp'),
+    'ES2': ('ec', 'temperature'),
     'ATLAS_DO': ('do',),
     'ATLAS_PH': ('ph',),
 }
@@ -96,7 +96,7 @@ Defines dataframe field names for known data types in v4.1.0 logfiles.
 
 _DATA_FIELDS_v4_2_0 = {
     'BATTERY': ('voltage', 'm0_current', 'm1_current'),
-    'ES2': ('ec', 'temp'),
+    'ES2': ('ec', 'temperature'),
     'ATLAS_DO': ('do',),
     'ATLAS_PH': ('ph',),
 }

--- a/src/platypus/io/logs.py
+++ b/src/platypus/io/logs.py
@@ -4,6 +4,7 @@ Module for handling the import of various logfiles into numpy arrays.
 Copyright 2015. Platypus LLC. All rights reserved.
 """
 import collections
+import datetime
 import logging
 import itertools
 import json
@@ -275,12 +276,14 @@ def read_v4_0_0(logfile, filename):
     if not m:
         raise ValueError(
             "v4.0.0 log files must be named 'airboat_<date>_<time>.txt'.")
-    start_time = np.datetime64(int(m.group('year')),
-                               int(m.group('month')),
-                               int(m.group('day')),
-                               int(m.group('hour')),
-                               int(m.group('minute')),
-                               int(m.group('second')))
+    start_time = np.datetime64(datetime.datetime(
+        int(m.group('year')),
+        int(m.group('month')),
+        int(m.group('day')),
+        int(m.group('hour')),
+        int(m.group('minute')),
+        int(m.group('second'))
+    )
 
     for line in logfile:
         # First, parse out the timestamp:

--- a/src/platypus/io/logs.py
+++ b/src/platypus/io/logs.py
@@ -363,7 +363,9 @@ def read_v4_0_0(logfile, filename):
     unlabeled_sensor_data = {
         sensor_type: np.array(
             sensor_value,
-            dtype=[('time', 'datetime64[ms]')] + [float] * len(sensor_value[0])
+            dtype=[('time', 'datetime64[ms]')] +
+                  [('channel' + i, float)
+                   for i, _ in enumerate(sensor_value[0])]
         )
         for sensor_type, sensor_value in six.viewitems(data_sensors)
         if sensor_type not in data

--- a/src/platypus/io/logs.py
+++ b/src/platypus/io/logs.py
@@ -352,7 +352,7 @@ def read_v4_0_0(logfile, filename):
         if k in _DATA_FIELDS_v4_0_0:
             fields = [('time', 'datetime64[ms]')]
             fields += [(field_name, float)
-                       for field_name in _DATA_FIELDS_v4_2_0[k]]
+                       for field_name in _DATA_FIELDS_v4_0_0[k]]
             data[k] = np.rec.array(v, dtype=fields)
 
     # Return merged data structure.

--- a/src/platypus/io/logs.py
+++ b/src/platypus/io/logs.py
@@ -283,7 +283,7 @@ def read_v4_0_0(logfile, filename):
         int(m.group('hour')),
         int(m.group('minute')),
         int(m.group('second'))
-    )
+    ))
 
     for line in logfile:
         # First, parse out the timestamp:

--- a/src/platypus/io/logs.py
+++ b/src/platypus/io/logs.py
@@ -338,15 +338,15 @@ def read_v4_0_0(logfile, filename):
     data = {}
 
     data['pose'] = add_ll_to_pose_dataframe(
-            remove_outliers_from_pose_dataframe(
-                np.rec.array(data_pose, dtype=[('time', 'datetime64[ms]'),
-                                               ('easting', float),
-                                               ('northing', float),
-                                               ('altitude', float),
-                                               ('zone', int),
-                                               ('hemi', bool)])
-            )
+        remove_outliers_from_pose_dataframe(
+            np.rec.array(data_pose, dtype=[('time', 'datetime64[ms]'),
+                                           ('easting', float),
+                                           ('northing', float),
+                                           ('altitude', float),
+                                           ('zone', int),
+                                           ('hemi', bool)])
         )
+    )
 
     for k, v in six.viewitems(data_sensors):
         if k in _DATA_FIELDS_v4_0_0:

--- a/tests/platypus/io/test_logs.py
+++ b/tests/platypus/io/test_logs.py
@@ -95,7 +95,7 @@ class LogsTest(TestCase):
         self.assertAlmostEqual(log['ATLAS_DO']['do'][-1], 10.56)
 
         # Test that the correct pose entries were loaded.
-        self.assertEqual(log['pose'].shape, (211, 7))
+        self.assertEqual(log['pose'].shape, (211,))
         self.assertAlmostEqual(log['pose']['easting'][0], 337185.1208144073)
         self.assertAlmostEqual(log['pose']['northing'][0], 4467663.6643868135)
         self.assertAlmostEqual(log['pose']['easting'][-1], 337679.211030486)
@@ -122,7 +122,7 @@ class LogsTest(TestCase):
         self.assertAlmostEqual(log['ATLAS_DO']['do'][-1], 7.47)
 
         # Test that the correct pose entries were loaded.
-        self.assertEqual(log['pose'].shape, (571, 7))
+        self.assertEqual(log['pose'].shape, (571,))
         self.assertAlmostEqual(log['pose']['easting'][0], 592295.4032107397),
         self.assertAlmostEqual(log['pose']['northing'][0], 4481766.791869606)
         self.assertAlmostEqual(log['pose']['easting'][-1], 592300.9984074512)

--- a/tests/platypus/io/test_logs.py
+++ b/tests/platypus/io/test_logs.py
@@ -1,3 +1,4 @@
+import numpy
 import platypus.io.logs
 import os
 from unittest import TestCase
@@ -43,19 +44,18 @@ class LogsTest(TestCase):
 
     def test_read_v4_0_0_sensor(self):
         """ Test reading a v4.0.0 logfile with sensors. """
-        import numpy
-
         with open(TEST_LOG_V4_0_0_SENSOR_FILENAME) as log_file:
             log_v4_0_0_str = log_file.readlines()
         log_v4_0_0 = platypus.io.logs.read(
             log_v4_0_0_str, filename=TEST_LOG_V4_0_0_SENSOR_FILENAME)
 
         # Test that the correct battery sensor entries were loaded.
-        self.assertTrue(numpy.allclose(
-            log_v4_0_0['battery'][['voltage', 'm0_current', 'm1_current']],
-            numpy.array([[12.463, 9045.454102, 0.],
-                         [12.463, 0., 15.151515]])
-        ))
+        self.assertAlmostEqual(log_v4_0_0['battery']['voltage'][0], 12.463)
+        self.assertAlmostEqual(log_v4_0_0['battery']['m0_current'][0], 9045.454102)
+        self.assertAlmostEqual(log_v4_0_0['battery']['m1_current'][0], 0.)
+        self.assertAlmostEqual(log_v4_0_0['battery']['voltage'][-1], 12.463)
+        self.assertAlmostEqual(log_v4_0_0['battery']['m0_current'][-1], 0.)
+        self.assertAlmostEqual(log_v4_0_0['battery']['m1_current'][-1], 15.151515)
 
         # Test that the correct atlas_do sensor entries were loaded.
         self.assertTrue(numpy.allclose(

--- a/tests/platypus/io/test_logs.py
+++ b/tests/platypus/io/test_logs.py
@@ -30,12 +30,12 @@ class LogsTest(TestCase):
             log_v4_0_0_str, filename=TEST_LOG_V4_0_0_FILENAME)
 
         # Test that the correct number of ES2 entries were loaded.
-        self.assertEqual(log_v4_0_0['es2'].shape, (22, 2))
+        self.assertEqual(log_v4_0_0['es2'].shape, (22,))
         self.assertEqual(log_v4_0_0['es2']['temperature'][-1], 10.0)
         self.assertEqual(log_v4_0_0['es2']['ec'][-1], 9.0)
 
         # Test that the correct pose entries were loaded.
-        self.assertEqual(log_v4_0_0['pose'].shape, (95, 7))
+        self.assertEqual(log_v4_0_0['pose'].shape, (95,))
         self.assertAlmostEqual(log_v4_0_0['pose']['longitude'][-1],
                                -79.917394651365555)
         self.assertAlmostEqual(log_v4_0_0['pose']['latitude'][-1],
@@ -52,19 +52,19 @@ class LogsTest(TestCase):
 
         # Test that the correct battery sensor entries were loaded.
         self.assertTrue(numpy.allclose(
-            log_v4_0_0['battery'].as_matrix(),
+            log_v4_0_0['battery'][['voltage', 'm0_current', 'm1_current']],
             numpy.array([[12.463, 9045.454102, 0.],
                          [12.463, 0., 15.151515]])
         ))
 
         # Test that the correct atlas_do sensor entries were loaded.
         self.assertTrue(numpy.allclose(
-            log_v4_0_0['atlas_do'].as_matrix(),
+            log_v4_0_0['atlas_do']['do'],
             numpy.array([[7.78]])
         ))
 
         # Test that the correct pose entries were loaded.
-        self.assertEqual(log_v4_0_0['pose'].shape, (15, 7))
+        self.assertEqual(log_v4_0_0['pose'].shape, (15,))
         self.assertAlmostEqual(log_v4_0_0['pose']['longitude'][0],
                                -81.2833044)
         self.assertAlmostEqual(log_v4_0_0['pose']['latitude'][0],
@@ -81,18 +81,18 @@ class LogsTest(TestCase):
         log = platypus.io.logs.read_v4_1_0(log_str)
 
         # Test that the correct battery sensor entries were loaded.
-        self.assertEqual(log['BATTERY'].shape, (12, 3))
-        self.assertAlmostEqual(log['BATTERY'].as_matrix()[0, 0], 15.263)
-        self.assertAlmostEqual(log['BATTERY'].as_matrix()[-1, 0], 15.015)
+        self.assertEqual(log['BATTERY'].shape, (12,))
+        self.assertAlmostEqual(log['BATTERY']['voltage'][0], 15.263)
+        self.assertAlmostEqual(log['BATTERY']['voltage'][-1], 15.015)
 
         # Test that the correct atlas sensor entries were loaded.
-        self.assertEqual(log['ATLAS_PH'].shape, (11, 1))
-        self.assertAlmostEqual(log['ATLAS_PH'].as_matrix()[0, 0], 7.054)
-        self.assertAlmostEqual(log['ATLAS_PH'].as_matrix()[-1, 0], 6.7)
+        self.assertEqual(log['ATLAS_PH'].shape, (11,))
+        self.assertAlmostEqual(log['ATLAS_PH']['ph'][0], 7.054)
+        self.assertAlmostEqual(log['ATLAS_PH']['ph'][-1], 6.7)
 
-        self.assertEqual(log['ATLAS_DO'].shape, (21, 1))
-        self.assertAlmostEqual(log['ATLAS_DO'].as_matrix()[0, 0], 10.15)
-        self.assertAlmostEqual(log['ATLAS_DO'].as_matrix()[-1, 0], 10.56)
+        self.assertEqual(log['ATLAS_DO'].shape, (21,))
+        self.assertAlmostEqual(log['ATLAS_DO']['do'][0], 10.15)
+        self.assertAlmostEqual(log['ATLAS_DO']['do'][-1], 10.56)
 
         # Test that the correct pose entries were loaded.
         self.assertEqual(log['pose'].shape, (211, 7))
@@ -108,18 +108,18 @@ class LogsTest(TestCase):
         log = platypus.io.logs.read_v4_2_0(log_str)
 
         # Test that the correct battery sensor entries were loaded.
-        self.assertEqual(log['BATTERY'].shape, (46, 3))
-        self.assertAlmostEqual(log['BATTERY'].as_matrix()[0, 0], 17.075)
-        self.assertAlmostEqual(log['BATTERY'].as_matrix()[-1, 0], 17.048)
+        self.assertEqual(log['BATTERY'].shape, (46,))
+        self.assertAlmostEqual(log['BATTERY']['voltage'][0], 17.075)
+        self.assertAlmostEqual(log['BATTERY']['voltage'][-1], 17.048)
 
         # Test that the correct atlas sensor entries were loaded.
-        self.assertEqual(log['ATLAS_PH'].shape, (10, 1))
-        self.assertAlmostEqual(log['ATLAS_PH'].as_matrix()[0, 0], 4.473)
-        self.assertAlmostEqual(log['ATLAS_PH'].as_matrix()[-1, 0], 4.448)
+        self.assertEqual(log['ATLAS_PH'].shape, (10,))
+        self.assertAlmostEqual(log['ATLAS_PH']['ph'][0], 4.473)
+        self.assertAlmostEqual(log['ATLAS_PH']['ph'][-1], 4.448)
 
-        self.assertEqual(log['ATLAS_DO'].shape, (14, 1))
-        self.assertAlmostEqual(log['ATLAS_DO'].as_matrix()[0, 0], 7.49)
-        self.assertAlmostEqual(log['ATLAS_DO'].as_matrix()[-1, 0], 7.47)
+        self.assertEqual(log['ATLAS_DO'].shape, (14,))
+        self.assertAlmostEqual(log['ATLAS_DO']['do'][0], 7.49)
+        self.assertAlmostEqual(log['ATLAS_DO']['do'][-1], 7.47)
 
         # Test that the correct pose entries were loaded.
         self.assertEqual(log['pose'].shape, (571, 7))


### PR DESCRIPTION
Instead of `pandas`, load and save functionality uses `numpy.recarray`.

While `pandas` adds a lot of additional functionality, it is also a fairly heavy dependency and can make many simple operations like interpolation very complicated.

If `pandas` is necessary, the `numpy.recarray` structure can be converted to a `pandas.DataFrame`.

This PR also reorganizes the `setup.py` and `.travis.yml` files to add coverage test reporting to the analytics library.
